### PR TITLE
Update AMIs to version 12.2.6

### DIFF
--- a/templates/openedge-database.template.yaml
+++ b/templates/openedge-database.template.yaml
@@ -66,43 +66,43 @@ Mappings:
     AMI:
       OEDBAMZNLINUX2: Amazon Linux 2 AMI with OpenEdge Database
     af-south-1:
-      OEDBAMZNLINUX2: ami-0e02b8f101080c860
+      OEDBAMZNLINUX2: ami-01b8227085146774b
     ap-east-1:
-      OEDBAMZNLINUX2: ami-0028e76d264c49d58
+      OEDBAMZNLINUX2: ami-09d03d987fa2cf8ef
     ap-northeast-1:
-      OEDBAMZNLINUX2: ami-03e9a7f428f86afb5
+      OEDBAMZNLINUX2: ami-07af7b29a23cb795b
     ap-northeast-2:
-      OEDBAMZNLINUX2: ami-085867c1ec05e3d12
+      OEDBAMZNLINUX2: ami-00d6ce38f5c08bd20
     ap-south-1:
-      OEDBAMZNLINUX2: ami-044b122f91731f3d5
+      OEDBAMZNLINUX2: ami-075f9dfd0c3301763
     ap-southeast-1:
-      OEDBAMZNLINUX2: ami-051c2efd83ec16118
+      OEDBAMZNLINUX2: ami-02b6d48abc78987c2
     ap-southeast-2:
-      OEDBAMZNLINUX2: ami-00cff12184f288dd4
+      OEDBAMZNLINUX2: ami-0bdaed3c473c01ee7
     ca-central-1:
-      OEDBAMZNLINUX2: ami-0377d3f773dbf351b
+      OEDBAMZNLINUX2: ami-0afbcfd1cb155c524
     eu-central-1:
-      OEDBAMZNLINUX2: ami-0b0ad022d3b1d0635
+      OEDBAMZNLINUX2: ami-0b04a36205a865081
     eu-north-1:
-      OEDBAMZNLINUX2: ami-0f4aad1eec158009b
+      OEDBAMZNLINUX2: ami-09b7174d11252788c
     eu-south-1:
-      OEDBAMZNLINUX2: ami-0f9155fd22102c26e
+      OEDBAMZNLINUX2: ami-0eebf498057af36b6
     eu-west-1:
-      OEDBAMZNLINUX2: ami-04717e3a535c18acd
+      OEDBAMZNLINUX2: ami-094d2cd1aed932834
     eu-west-2:
-      OEDBAMZNLINUX2: ami-0a12a304843439d6f
+      OEDBAMZNLINUX2: ami-0b443af6b0a72b3c2
     eu-west-3:
-      OEDBAMZNLINUX2: ami-0a561eca7c7f44082
+      OEDBAMZNLINUX2: ami-0607fccda5729077f
     sa-east-1:
-      OEDBAMZNLINUX2: ami-0ac4686074285c467
+      OEDBAMZNLINUX2: ami-0238b10b740d46d3d
     us-east-1:
-      OEDBAMZNLINUX2: ami-0bf4db03f64f2d604
+      OEDBAMZNLINUX2: ami-0c6dd059ee5c0c633
     us-east-2:
-      OEDBAMZNLINUX2: ami-078a3e307ceb0b5e2
+      OEDBAMZNLINUX2: ami-018197b61b31a18ab
     us-west-1:
-      OEDBAMZNLINUX2: ami-0439069a7d2b0f4dc
+      OEDBAMZNLINUX2: ami-0002daf18a229541a
     us-west-2:
-      OEDBAMZNLINUX2: ami-03b02f8cee114fd06
+      OEDBAMZNLINUX2: ami-0136128e167eac4ae
 Resources:
   NotificationTopic:
     Type: "AWS::SNS::Topic"

--- a/templates/openedge-pasoe.template.yaml
+++ b/templates/openedge-pasoe.template.yaml
@@ -82,43 +82,43 @@ Mappings:
     AMI:
       PASOEAMZNLINUX2: Amazon Linux 2 AMI with PAS for OpenEdge
     af-south-1:
-      PASOEAMZNLINUX2: ami-0cf7df69b9c8982eb
+      PASOEAMZNLINUX2: ami-098c6679f18127cf3
     ap-east-1:
-      PASOEAMZNLINUX2: ami-0ce220964bcaef06b
+      PASOEAMZNLINUX2: ami-04399f1af4d4a757b
     ap-northeast-1:
-      PASOEAMZNLINUX2: ami-0f68d1fd7936fbf5a
+      PASOEAMZNLINUX2: ami-0a0dfc0ee2000117b
     ap-northeast-2:
-      PASOEAMZNLINUX2: ami-099c57553e27a9d1a
+      PASOEAMZNLINUX2: ami-07e1aa13a97050236
     ap-south-1:
-      PASOEAMZNLINUX2: ami-0c94f3a94b9618c02
+      PASOEAMZNLINUX2: ami-0244e02bcccca2ed5
     ap-southeast-1:
-      PASOEAMZNLINUX2: ami-0ba9c5af5782a50c6
+      PASOEAMZNLINUX2: ami-0b809c5b46d894417
     ap-southeast-2:
-      PASOEAMZNLINUX2: ami-091d949407dd512db
+      PASOEAMZNLINUX2: ami-0679d6ad14b177593
     ca-central-1:
-      PASOEAMZNLINUX2: ami-0294237ea18275104
+      PASOEAMZNLINUX2: ami-0cfc7393b8902b00a
     eu-central-1:
-      PASOEAMZNLINUX2: ami-0ae4d65c8875a4493
+      PASOEAMZNLINUX2: ami-062513d4f53ab87bd
     eu-north-1:
-      PASOEAMZNLINUX2: ami-0a66e4b469a9a5584
+      PASOEAMZNLINUX2: ami-0b2e979fa69aaac7d
     eu-south-1:
-      PASOEAMZNLINUX2: ami-0d9db71f6144b1aaf
+      PASOEAMZNLINUX2: ami-047e5eacedab72bfd
     eu-west-1:
-      PASOEAMZNLINUX2: ami-04876ea318f5d645e
+      PASOEAMZNLINUX2: ami-03ee720fa13f6e28f
     eu-west-2:
-      PASOEAMZNLINUX2: ami-0debbd89379757bf3
+      PASOEAMZNLINUX2: ami-01839ea9d30f3961d
     eu-west-3:
-      PASOEAMZNLINUX2: ami-0f66787bca381850f
+      PASOEAMZNLINUX2: ami-06041f62451752841
     sa-east-1:
-      PASOEAMZNLINUX2: ami-02d1277146ba0195b
+      PASOEAMZNLINUX2: ami-038a50d32ee4afc8a
     us-east-1:
-      PASOEAMZNLINUX2: ami-079b0ffcb6bab5e97
+      PASOEAMZNLINUX2: ami-0ab388d63653b92e9
     us-east-2:
-      PASOEAMZNLINUX2: ami-0b3480f434dc86c60
+      PASOEAMZNLINUX2: ami-0de6207a1f6a49fff
     us-west-1:
-      PASOEAMZNLINUX2: ami-0f198231121d3bfb2
+      PASOEAMZNLINUX2: ami-0be6bf5e85a74bb47
     us-west-2:
-      PASOEAMZNLINUX2: ami-0df7ac3355c904107
+      PASOEAMZNLINUX2: ami-0291c076833b761a2
 Resources:
   NotificationTopic:
     Type: 'AWS::SNS::Topic'


### PR DESCRIPTION
*Description of changes:*

Updated OpenEdge on AWS Quick Start to use OpenEdge 12.2.6 AMIs (latest in AWS Marketplace).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
