### PR TITLE
Update to version 12.2.10

### DIFF
--- a/templates/openedge-database.template.yaml
+++ b/templates/openedge-database.template.yaml
@@ -66,43 +66,43 @@ Mappings:
     AMI:
       OEDBAMZNLINUX2: Amazon Linux 2 AMI with OpenEdge Database
     af-south-1:
-      OEDBAMZNLINUX2: ami-01b8227085146774b
+      OEDBAMZNLINUX2: ami-01c73636859549498
     ap-east-1:
-      OEDBAMZNLINUX2: ami-09d03d987fa2cf8ef
+      OEDBAMZNLINUX2: ami-0cdeb044c645691b4
     ap-northeast-1:
-      OEDBAMZNLINUX2: ami-07af7b29a23cb795b
+      OEDBAMZNLINUX2: ami-05e8c709fe67beee8
     ap-northeast-2:
-      OEDBAMZNLINUX2: ami-00d6ce38f5c08bd20
+      OEDBAMZNLINUX2: ami-0d261084b83e2e196
     ap-south-1:
-      OEDBAMZNLINUX2: ami-075f9dfd0c3301763
+      OEDBAMZNLINUX2: ami-0580bb8aa5138f189
     ap-southeast-1:
-      OEDBAMZNLINUX2: ami-02b6d48abc78987c2
+      OEDBAMZNLINUX2: ami-05edf8978e91a8bf0
     ap-southeast-2:
-      OEDBAMZNLINUX2: ami-0bdaed3c473c01ee7
+      OEDBAMZNLINUX2: ami-0f55f3a20ef29d9c5
     ca-central-1:
-      OEDBAMZNLINUX2: ami-0afbcfd1cb155c524
+      OEDBAMZNLINUX2: ami-0554ab9aaa47d698d
     eu-central-1:
-      OEDBAMZNLINUX2: ami-0b04a36205a865081
+      OEDBAMZNLINUX2: ami-002da9196db239cc7
     eu-north-1:
-      OEDBAMZNLINUX2: ami-09b7174d11252788c
+      OEDBAMZNLINUX2: ami-0d410adb3583ce292
     eu-south-1:
-      OEDBAMZNLINUX2: ami-0eebf498057af36b6
+      OEDBAMZNLINUX2: ami-096c1ef55c7fd8a06
     eu-west-1:
-      OEDBAMZNLINUX2: ami-094d2cd1aed932834
+      OEDBAMZNLINUX2: ami-059729eb93ef6b666
     eu-west-2:
-      OEDBAMZNLINUX2: ami-0b443af6b0a72b3c2
+      OEDBAMZNLINUX2: ami-07e80e872a2484bce
     eu-west-3:
-      OEDBAMZNLINUX2: ami-0607fccda5729077f
+      OEDBAMZNLINUX2: ami-014ec01d563109e34
     sa-east-1:
-      OEDBAMZNLINUX2: ami-0238b10b740d46d3d
+      OEDBAMZNLINUX2: ami-0babff01c9aae4922
     us-east-1:
-      OEDBAMZNLINUX2: ami-0c6dd059ee5c0c633
+      OEDBAMZNLINUX2: ami-0e12666de7d0176d6
     us-east-2:
-      OEDBAMZNLINUX2: ami-018197b61b31a18ab
+      OEDBAMZNLINUX2: ami-03d9dbf1db41f13bb
     us-west-1:
-      OEDBAMZNLINUX2: ami-0002daf18a229541a
+      OEDBAMZNLINUX2: ami-0b192a6ab2f6ea4d6
     us-west-2:
-      OEDBAMZNLINUX2: ami-0136128e167eac4ae
+      OEDBAMZNLINUX2: ami-0573c0826395ec74d
 Resources:
   NotificationTopic:
     Type: "AWS::SNS::Topic"

--- a/templates/openedge-pasoe.template.yaml
+++ b/templates/openedge-pasoe.template.yaml
@@ -82,43 +82,43 @@ Mappings:
     AMI:
       PASOEAMZNLINUX2: Amazon Linux 2 AMI with PAS for OpenEdge
     af-south-1:
-      PASOEAMZNLINUX2: ami-098c6679f18127cf3
+      PASOEAMZNLINUX2: ami-057a0295f14ae2dbe
     ap-east-1:
-      PASOEAMZNLINUX2: ami-04399f1af4d4a757b
+      PASOEAMZNLINUX2: ami-0146ee721dff8d23c
     ap-northeast-1:
-      PASOEAMZNLINUX2: ami-0a0dfc0ee2000117b
+      PASOEAMZNLINUX2: ami-05016bf13ee342bb7
     ap-northeast-2:
-      PASOEAMZNLINUX2: ami-07e1aa13a97050236
+      PASOEAMZNLINUX2: ami-0f28fbd1a32d3b7a5
     ap-south-1:
-      PASOEAMZNLINUX2: ami-0244e02bcccca2ed5
+      PASOEAMZNLINUX2: ami-01949f4c78b61eaec
     ap-southeast-1:
-      PASOEAMZNLINUX2: ami-0b809c5b46d894417
+      PASOEAMZNLINUX2: ami-031115eff062dd3e6
     ap-southeast-2:
-      PASOEAMZNLINUX2: ami-0679d6ad14b177593
+      PASOEAMZNLINUX2: ami-0666cbd8ca3a73698
     ca-central-1:
-      PASOEAMZNLINUX2: ami-0cfc7393b8902b00a
+      PASOEAMZNLINUX2: ami-0a06948cfe9d941e7
     eu-central-1:
-      PASOEAMZNLINUX2: ami-062513d4f53ab87bd
+      PASOEAMZNLINUX2: ami-0e14b0c5e1ab43f47
     eu-north-1:
-      PASOEAMZNLINUX2: ami-0b2e979fa69aaac7d
+      PASOEAMZNLINUX2: ami-06fc7f880b4469c16
     eu-south-1:
-      PASOEAMZNLINUX2: ami-047e5eacedab72bfd
+      PASOEAMZNLINUX2: ami-0bc2dd222eaddde21
     eu-west-1:
-      PASOEAMZNLINUX2: ami-03ee720fa13f6e28f
+      PASOEAMZNLINUX2: ami-09bf9c3b0493c9569
     eu-west-2:
-      PASOEAMZNLINUX2: ami-01839ea9d30f3961d
+      PASOEAMZNLINUX2: ami-04516eaa57902b285
     eu-west-3:
-      PASOEAMZNLINUX2: ami-06041f62451752841
+      PASOEAMZNLINUX2: ami-008002eb0bb0f59a2
     sa-east-1:
-      PASOEAMZNLINUX2: ami-038a50d32ee4afc8a
+      PASOEAMZNLINUX2: ami-09155f7b1be32f264
     us-east-1:
-      PASOEAMZNLINUX2: ami-0ab388d63653b92e9
+      PASOEAMZNLINUX2: ami-0b3bc3a12445d4c00
     us-east-2:
-      PASOEAMZNLINUX2: ami-0de6207a1f6a49fff
+      PASOEAMZNLINUX2: ami-0723f033c5d7a9400
     us-west-1:
-      PASOEAMZNLINUX2: ami-0be6bf5e85a74bb47
+      PASOEAMZNLINUX2: ami-0e1f3d4ed8ae048a4
     us-west-2:
-      PASOEAMZNLINUX2: ami-0291c076833b761a2
+      PASOEAMZNLINUX2: ami-08ca23fed18d013fa
 Resources:
   NotificationTopic:
     Type: 'AWS::SNS::Topic'


### PR DESCRIPTION
Description of changes:

Updated OpenEdge on AWS Quick Start to use OpenEdge 12.2.10 AMIs (latest in AWS Marketplace).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.