### PR TITLE
Update to version 12.2.11

### DIFF
--- a/templates/openedge-database.template.yaml
+++ b/templates/openedge-database.template.yaml
@@ -66,43 +66,43 @@ Mappings:
     AMI:
       OEDBAMZNLINUX2: Amazon Linux 2 AMI with OpenEdge Database
     af-south-1:
-      OEDBAMZNLINUX2: ami-01c73636859549498
+      PASOEAMZNLINUX2: ami-0483b4c1afb4eda46
     ap-east-1:
-      OEDBAMZNLINUX2: ami-0cdeb044c645691b4
+      PASOEAMZNLINUX2: ami-0f34f73c9c1c4c5a1
     ap-northeast-1:
-      OEDBAMZNLINUX2: ami-05e8c709fe67beee8
+      PASOEAMZNLINUX2: ami-029df9bb050ef8112
     ap-northeast-2:
-      OEDBAMZNLINUX2: ami-0d261084b83e2e196
+      PASOEAMZNLINUX2: ami-0e229f9260ad0b013
     ap-south-1:
-      OEDBAMZNLINUX2: ami-0580bb8aa5138f189
+      PASOEAMZNLINUX2: ami-02a0dbded0d8b8096
     ap-southeast-1:
-      OEDBAMZNLINUX2: ami-05edf8978e91a8bf0
+      PASOEAMZNLINUX2: ami-0a0385bc25f45793e
     ap-southeast-2:
-      OEDBAMZNLINUX2: ami-0f55f3a20ef29d9c5
+      PASOEAMZNLINUX2: ami-0871f7e7f3afeedb3
     ca-central-1:
-      OEDBAMZNLINUX2: ami-0554ab9aaa47d698d
+      PASOEAMZNLINUX2: ami-0aeaeac94c2608b8f
     eu-central-1:
-      OEDBAMZNLINUX2: ami-002da9196db239cc7
+      PASOEAMZNLINUX2: ami-0a2e6a23a0a4781b9
     eu-north-1:
-      OEDBAMZNLINUX2: ami-0d410adb3583ce292
+      PASOEAMZNLINUX2: ami-05fbeddf4f4483977
     eu-south-1:
-      OEDBAMZNLINUX2: ami-096c1ef55c7fd8a06
+      PASOEAMZNLINUX2: ami-0347b276719afd4e4
     eu-west-1:
-      OEDBAMZNLINUX2: ami-059729eb93ef6b666
+      PASOEAMZNLINUX2: ami-0d11972d0008af076
     eu-west-2:
-      OEDBAMZNLINUX2: ami-07e80e872a2484bce
+      PASOEAMZNLINUX2: ami-0cb95ff0a8a76a9a8
     eu-west-3:
-      OEDBAMZNLINUX2: ami-014ec01d563109e34
+      PASOEAMZNLINUX2: ami-00a3f3b6e1e30a117
     sa-east-1:
-      OEDBAMZNLINUX2: ami-0babff01c9aae4922
+      PASOEAMZNLINUX2: ami-09a5810b9df3765b3
     us-east-1:
-      OEDBAMZNLINUX2: ami-0e12666de7d0176d6
+      PASOEAMZNLINUX2: ami-0a0664d4ac87ed6b6
     us-east-2:
-      OEDBAMZNLINUX2: ami-03d9dbf1db41f13bb
+      PASOEAMZNLINUX2: ami-092fe5237e3926fde
     us-west-1:
-      OEDBAMZNLINUX2: ami-0b192a6ab2f6ea4d6
+      PASOEAMZNLINUX2: ami-04ddd8681266f6db9
     us-west-2:
-      OEDBAMZNLINUX2: ami-0573c0826395ec74d
+      PASOEAMZNLINUX2: ami-08c078385c21f45ef
 Resources:
   NotificationTopic:
     Type: "AWS::SNS::Topic"

--- a/templates/openedge-pasoe.template.yaml
+++ b/templates/openedge-pasoe.template.yaml
@@ -82,43 +82,43 @@ Mappings:
     AMI:
       PASOEAMZNLINUX2: Amazon Linux 2 AMI with PAS for OpenEdge
     af-south-1:
-      PASOEAMZNLINUX2: ami-057a0295f14ae2dbe
+      PASOEAMZNLINUX2: ami-040e27609bb7bf63c
     ap-east-1:
-      PASOEAMZNLINUX2: ami-0146ee721dff8d23c
+      PASOEAMZNLINUX2: ami-0ed126a2cb535416b
     ap-northeast-1:
-      PASOEAMZNLINUX2: ami-05016bf13ee342bb7
+      PASOEAMZNLINUX2: ami-0b0a1707f6ed180d9
     ap-northeast-2:
-      PASOEAMZNLINUX2: ami-0f28fbd1a32d3b7a5
+      PASOEAMZNLINUX2: ami-004b652dd831ab468
     ap-south-1:
-      PASOEAMZNLINUX2: ami-01949f4c78b61eaec
+      PASOEAMZNLINUX2: ami-063596b1500b76519
     ap-southeast-1:
-      PASOEAMZNLINUX2: ami-031115eff062dd3e6
+      PASOEAMZNLINUX2: ami-0a4e99879372d6066
     ap-southeast-2:
-      PASOEAMZNLINUX2: ami-0666cbd8ca3a73698
+      PASOEAMZNLINUX2: ami-0e2213fe83891355b
     ca-central-1:
-      PASOEAMZNLINUX2: ami-0a06948cfe9d941e7
+      PASOEAMZNLINUX2: ami-0287de51dbea8991c
     eu-central-1:
-      PASOEAMZNLINUX2: ami-0e14b0c5e1ab43f47
+      PASOEAMZNLINUX2: ami-02421d3a9129b8ea4
     eu-north-1:
-      PASOEAMZNLINUX2: ami-06fc7f880b4469c16
+      PASOEAMZNLINUX2: ami-04caa36c22f41e4c3
     eu-south-1:
-      PASOEAMZNLINUX2: ami-0bc2dd222eaddde21
+      PASOEAMZNLINUX2: ami-0aaa1455fbcaf2d0d
     eu-west-1:
-      PASOEAMZNLINUX2: ami-09bf9c3b0493c9569
+      PASOEAMZNLINUX2: ami-0bcb9e5f58cf2cfc3
     eu-west-2:
-      PASOEAMZNLINUX2: ami-04516eaa57902b285
+      PASOEAMZNLINUX2: ami-0f865abc869dbc765
     eu-west-3:
-      PASOEAMZNLINUX2: ami-008002eb0bb0f59a2
+      PASOEAMZNLINUX2: ami-081e3b578af96619e
     sa-east-1:
-      PASOEAMZNLINUX2: ami-09155f7b1be32f264
+      PASOEAMZNLINUX2: ami-05fe9a1870842ae63
     us-east-1:
-      PASOEAMZNLINUX2: ami-0b3bc3a12445d4c00
+      PASOEAMZNLINUX2: ami-0b9eb7bc90d3cd1bc
     us-east-2:
-      PASOEAMZNLINUX2: ami-0723f033c5d7a9400
+      PASOEAMZNLINUX2: ami-06ba8adbf1d9d25eb
     us-west-1:
-      PASOEAMZNLINUX2: ami-0e1f3d4ed8ae048a4
+      PASOEAMZNLINUX2: ami-0473e5272cfeb7032
     us-west-2:
-      PASOEAMZNLINUX2: ami-08ca23fed18d013fa
+      PASOEAMZNLINUX2: ami-0a576313b11606919
 Resources:
   NotificationTopic:
     Type: 'AWS::SNS::Topic'
@@ -384,4 +384,3 @@ Outputs:
         - !GetAtt 
           - ApplicationLoadBalancer
           - DNSName
-


### PR DESCRIPTION
*Description of changes:*

Updated OpenEdge on AWS Quick Start to use OpenEdge 12.2.11 AMIs (latest in AWS Marketplace).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
