### PR TITLE
Update to version 12.2.12

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -1,0 +1,1 @@
+language_type: cloudformation

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @davmayd
+* @davmayd @aws-quickstart/aws_quickstart_team

--- a/templates/master.template.yaml
+++ b/templates/master.template.yaml
@@ -214,7 +214,7 @@ Parameters:
 	  - m6a.32xlarge
 	  - m6a.48xlarge
     ConstraintDescription: "Must be a valid EC2 instance type."
-    Default: t3.medium
+    Default: t3.large
     Description: "EC2 instance type"
     Type: String
   BastionAMIOS:
@@ -242,7 +242,7 @@ Parameters:
       - m6i.xlarge
       - m6i.2xlarge
       - m6i.4xlarge
-    Default: t2.micro
+    Default: t3.micro
     Description: Amazon EC2 instance type for the bastion instances.
     Type: String
   KeyPairName:

--- a/templates/master.template.yaml
+++ b/templates/master.template.yaml
@@ -80,7 +80,7 @@ Metadata:
         default: Web deploy package
       PortNumber:
         default: Port number
-      MinPort: 
+      MinPort:
         default: Min port
       MaxPort:
         default: Max port
@@ -159,13 +159,57 @@ Parameters:
     Type: List<AWS::EC2::AvailabilityZone::Name>
   InstanceType:
     AllowedValues:
-      - t3a.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
       - t3a.medium
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
+	  - m6i.xlarge
+	  - m6i.2xlarge
+	  - m6i.4xlarge
+	  - m6i.8xlarge
+	  - m6i.12xlarge
+	  - m6i.16xlarge
+	  - m6i.24xlarge
+	  - m6i.32xlarge
+	  - m6id.xlarge
+	  - m6id.2xlarge
+	  - m6id.4xlarge
+	  - m6id.8xlarge
+	  - m6id.12xlarge
+	  - m6id.16xlarge
+	  - m6id.24xlarge
+	  - m6id.32xlarge
+	  - m6in.xlarge
+	  - m6in.2xlarge
+	  - m6in.4xlarge
+	  - m6in.8xlarge
+	  - m6in.12xlarge
+	  - m6in.16xlarge
+	  - m6in.24xlarge
+	  - m6in.32xlarge
+	  - m6idn.xlarge
+	  - m6idn.2xlarge
+	  - m6idn.4xlarge
+	  - m6idn.8xlarge
+	  - m6idn.12xlarge
+	  - m6idn.16xlarge
+	  - m6idn.24xlarge
+	  - m6idn.32xlarge
+	  - m6a.xlarge
+	  - m6a.2xlarge
+	  - m6a.4xlarge
+	  - m6a.8xlarge
+	  - m6a.12xlarge
+	  - m6a.16xlarge
+	  - m6a.24xlarge
+	  - m6a.32xlarge
+	  - m6a.48xlarge
     ConstraintDescription: "Must be a valid EC2 instance type."
-    Default: t3a.medium
+    Default: t3.medium
     Description: "EC2 instance type"
     Type: String
   BastionAMIOS:

--- a/templates/master.template.yaml
+++ b/templates/master.template.yaml
@@ -167,6 +167,7 @@ Parameters:
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
+	  - m6i.large
 	  - m6i.xlarge
 	  - m6i.2xlarge
 	  - m6i.4xlarge
@@ -175,6 +176,7 @@ Parameters:
 	  - m6i.16xlarge
 	  - m6i.24xlarge
 	  - m6i.32xlarge
+	  - m6id.large
 	  - m6id.xlarge
 	  - m6id.2xlarge
 	  - m6id.4xlarge
@@ -183,6 +185,7 @@ Parameters:
 	  - m6id.16xlarge
 	  - m6id.24xlarge
 	  - m6id.32xlarge
+	  - m6in.large
 	  - m6in.xlarge
 	  - m6in.2xlarge
 	  - m6in.4xlarge
@@ -191,6 +194,7 @@ Parameters:
 	  - m6in.16xlarge
 	  - m6in.24xlarge
 	  - m6in.32xlarge
+	  - m6idn.large
 	  - m6idn.xlarge
 	  - m6idn.2xlarge
 	  - m6idn.4xlarge
@@ -199,6 +203,7 @@ Parameters:
 	  - m6idn.16xlarge
 	  - m6idn.24xlarge
 	  - m6idn.32xlarge
+	  - m6a.large
 	  - m6a.xlarge
 	  - m6a.2xlarge
 	  - m6a.4xlarge

--- a/templates/master.template.yaml
+++ b/templates/master.template.yaml
@@ -223,18 +223,20 @@ Parameters:
     Type: String
   BastionInstanceType:
     AllowedValues:
-      - t2.nano
-      - t2.micro
-      - t2.small
-      - t2.medium
-      - t2.large
-      - m3.large
-      - m3.xlarge
-      - m3.2xlarge
-      - m4.large
-      - m4.xlarge
-      - m4.2xlarge
-      - m4.4xlarge
+      - t3.nano
+      - t3.micro
+      - t3.small
+      - t3.medium
+      - t3.large
+	  - t3.xlarge
+	  - t3.2xlarge
+      - m6i.large
+      - m6i.xlarge
+      - m6i.2xlarge
+      - m6i.large
+      - m6i.xlarge
+      - m6i.2xlarge
+      - m6i.4xlarge
     Default: t2.micro
     Description: Amazon EC2 instance type for the bastion instances.
     Type: String

--- a/templates/openedge-database.template.yaml
+++ b/templates/openedge-database.template.yaml
@@ -66,43 +66,43 @@ Mappings:
     AMI:
       OEDBAMZNLINUX2: Amazon Linux 2 AMI with OpenEdge Database
     af-south-1:
-      OEDBAMZNLINUX2: ami-01c73636859549498
+      PASOEAMZNLINUX2: ami-0483b4c1afb4eda46
     ap-east-1:
-      OEDBAMZNLINUX2: ami-0cdeb044c645691b4
+      PASOEAMZNLINUX2: ami-0f34f73c9c1c4c5a1
     ap-northeast-1:
-      OEDBAMZNLINUX2: ami-05e8c709fe67beee8
+      PASOEAMZNLINUX2: ami-029df9bb050ef8112
     ap-northeast-2:
-      OEDBAMZNLINUX2: ami-0d261084b83e2e196
+      PASOEAMZNLINUX2: ami-0e229f9260ad0b013
     ap-south-1:
-      OEDBAMZNLINUX2: ami-0580bb8aa5138f189
+      PASOEAMZNLINUX2: ami-02a0dbded0d8b8096
     ap-southeast-1:
-      OEDBAMZNLINUX2: ami-05edf8978e91a8bf0
+      PASOEAMZNLINUX2: ami-0a0385bc25f45793e
     ap-southeast-2:
-      OEDBAMZNLINUX2: ami-0f55f3a20ef29d9c5
+      PASOEAMZNLINUX2: ami-0871f7e7f3afeedb3
     ca-central-1:
-      OEDBAMZNLINUX2: ami-0554ab9aaa47d698d
+      PASOEAMZNLINUX2: ami-0aeaeac94c2608b8f
     eu-central-1:
-      OEDBAMZNLINUX2: ami-002da9196db239cc7
+      PASOEAMZNLINUX2: ami-0a2e6a23a0a4781b9
     eu-north-1:
-      OEDBAMZNLINUX2: ami-0d410adb3583ce292
+      PASOEAMZNLINUX2: ami-05fbeddf4f4483977
     eu-south-1:
-      OEDBAMZNLINUX2: ami-096c1ef55c7fd8a06
+      PASOEAMZNLINUX2: ami-0347b276719afd4e4
     eu-west-1:
-      OEDBAMZNLINUX2: ami-059729eb93ef6b666
+      PASOEAMZNLINUX2: ami-0d11972d0008af076
     eu-west-2:
-      OEDBAMZNLINUX2: ami-07e80e872a2484bce
+      PASOEAMZNLINUX2: ami-0cb95ff0a8a76a9a8
     eu-west-3:
-      OEDBAMZNLINUX2: ami-014ec01d563109e34
+      PASOEAMZNLINUX2: ami-00a3f3b6e1e30a117
     sa-east-1:
-      OEDBAMZNLINUX2: ami-0babff01c9aae4922
+      PASOEAMZNLINUX2: ami-09a5810b9df3765b3
     us-east-1:
-      OEDBAMZNLINUX2: ami-0e12666de7d0176d6
+      PASOEAMZNLINUX2: ami-0a0664d4ac87ed6b6
     us-east-2:
-      OEDBAMZNLINUX2: ami-03d9dbf1db41f13bb
+      PASOEAMZNLINUX2: ami-092fe5237e3926fde
     us-west-1:
-      OEDBAMZNLINUX2: ami-0b192a6ab2f6ea4d6
+      PASOEAMZNLINUX2: ami-04ddd8681266f6db9
     us-west-2:
-      OEDBAMZNLINUX2: ami-0573c0826395ec74d
+      PASOEAMZNLINUX2: ami-08c078385c21f45ef
 Resources:
   NotificationTopic:
     Type: "AWS::SNS::Topic"

--- a/templates/openedge-database.template.yaml
+++ b/templates/openedge-database.template.yaml
@@ -182,43 +182,43 @@ Mappings:
     AMI:
       OEDBAMZNLINUX2: Amazon Linux 2 AMI with OpenEdge Database
     af-south-1:
-      OEDBAMZNLINUX2: ami-01c73636859549498
+      OEDBAMZNLINUX2: ami-02b75f15c4cef540b
     ap-east-1:
-      OEDBAMZNLINUX2: ami-0cdeb044c645691b4
+      OEDBAMZNLINUX2: ami-0e7f1dfd20e0231c3
     ap-northeast-1:
-      OEDBAMZNLINUX2: ami-05e8c709fe67beee8
+      OEDBAMZNLINUX2: ami-085a33252f1fee74e
     ap-northeast-2:
-      OEDBAMZNLINUX2: ami-0d261084b83e2e196
+      OEDBAMZNLINUX2: ami-063b65912dda0e599
     ap-south-1:
-      OEDBAMZNLINUX2: ami-0580bb8aa5138f189
+      OEDBAMZNLINUX2: ami-0bcf9f77667f96966
     ap-southeast-1:
-      OEDBAMZNLINUX2: ami-05edf8978e91a8bf0
+      OEDBAMZNLINUX2: ami-07f9924758aab9a9f
     ap-southeast-2:
-      OEDBAMZNLINUX2: ami-0f55f3a20ef29d9c5
+      OEDBAMZNLINUX2: ami-0193dcf39b9412dc0
     ca-central-1:
-      OEDBAMZNLINUX2: ami-0554ab9aaa47d698d
+      OEDBAMZNLINUX2: ami-0931351a82f0fafcf
     eu-central-1:
-      OEDBAMZNLINUX2: ami-002da9196db239cc7
+      OEDBAMZNLINUX2: ami-0f57299ef84865a60
     eu-north-1:
-      OEDBAMZNLINUX2: ami-0d410adb3583ce292
+      OEDBAMZNLINUX2: ami-0eb6d8e034c3b26c9
     eu-south-1:
-      OEDBAMZNLINUX2: ami-096c1ef55c7fd8a06
+      OEDBAMZNLINUX2: ami-005303d2d2ca3b842
     eu-west-1:
-      OEDBAMZNLINUX2: ami-059729eb93ef6b666
+      OEDBAMZNLINUX2: ami-064aba9f09a2f0773
     eu-west-2:
-      OEDBAMZNLINUX2: ami-07e80e872a2484bce
+      OEDBAMZNLINUX2: ami-09c70c861bd6b80b0
     eu-west-3:
-      OEDBAMZNLINUX2: ami-014ec01d563109e34
+      OEDBAMZNLINUX2: ami-0e4dfcd87921f1198
     sa-east-1:
-      OEDBAMZNLINUX2: ami-0babff01c9aae4922
+      OEDBAMZNLINUX2: ami-0f1f1431655455b8d
     us-east-1:
-      OEDBAMZNLINUX2: ami-0e12666de7d0176d6
+      OEDBAMZNLINUX2: ami-079ae64665ebf4925
     us-east-2:
-      OEDBAMZNLINUX2: ami-03d9dbf1db41f13bb
+      OEDBAMZNLINUX2: ami-01bb7ffe18ddf4fe3
     us-west-1:
-      OEDBAMZNLINUX2: ami-0b192a6ab2f6ea4d6
+      OEDBAMZNLINUX2: ami-0bc216181300e667e
     us-west-2:
-      OEDBAMZNLINUX2: ami-0573c0826395ec74d
+      OEDBAMZNLINUX2: ami-0c99cc3a6bede73e6
 Resources:
   NotificationTopic:
     Type: "AWS::SNS::Topic"

--- a/templates/openedge-database.template.yaml
+++ b/templates/openedge-database.template.yaml
@@ -111,6 +111,7 @@ Parameters:
 	  - c6a.24xlarge
 	  - c6a.32xlarge
 	  - c6a.48xlarge
+	  - r6i.large
 	  - r6i.xlarge
 	  - r6i.2xlarge
 	  - r6i.4xlarge

--- a/templates/openedge-database.template.yaml
+++ b/templates/openedge-database.template.yaml
@@ -32,6 +32,7 @@ Parameters:
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
+	  - m6i.large
 	  - m6i.xlarge
 	  - m6i.2xlarge
 	  - m6i.4xlarge
@@ -40,6 +41,7 @@ Parameters:
 	  - m6i.16xlarge
 	  - m6i.24xlarge
 	  - m6i.32xlarge
+	  - m6id.large
 	  - m6id.xlarge
 	  - m6id.2xlarge
 	  - m6id.4xlarge
@@ -48,6 +50,7 @@ Parameters:
 	  - m6id.16xlarge
 	  - m6id.24xlarge
 	  - m6id.32xlarge
+	  - m6in.large
 	  - m6in.xlarge
 	  - m6in.2xlarge
 	  - m6in.4xlarge
@@ -56,6 +59,7 @@ Parameters:
 	  - m6in.16xlarge
 	  - m6in.24xlarge
 	  - m6in.32xlarge
+	  - m6idn.large
 	  - m6idn.xlarge
 	  - m6idn.2xlarge
 	  - m6idn.4xlarge
@@ -64,6 +68,7 @@ Parameters:
 	  - m6idn.16xlarge
 	  - m6idn.24xlarge
 	  - m6idn.32xlarge
+	  - m6a.large
 	  - m6a.xlarge
 	  - m6a.2xlarge
 	  - m6a.4xlarge
@@ -114,6 +119,7 @@ Parameters:
 	  - r6i.16xlarge
 	  - r6i.24xlarge
 	  - r6i.32xlarge
+	  - r6id.large
 	  - r6id.xlarge
 	  - r6id.2xlarge
 	  - r6id.4xlarge
@@ -122,6 +128,7 @@ Parameters:
 	  - r6id.16xlarge
 	  - r6id.24xlarge
 	  - r6id.32xlarge
+	  - r6in.large
 	  - r6in.xlarge
 	  - r6in.2xlarge
 	  - r6in.4xlarge
@@ -130,6 +137,7 @@ Parameters:
 	  - r6in.16xlarge
 	  - r6in.24xlarge
 	  - r6in.32xlarge
+	  - r6idn.large
 	  - r6idn.xlarge
 	  - r6idn.2xlarge
 	  - r6idn.4xlarge
@@ -138,6 +146,7 @@ Parameters:
 	  - r6idn.16xlarge
 	  - r6idn.24xlarge
 	  - r6idn.32xlarge
+	  - r6a.large
 	  - r6a.xlarge
 	  - r6a.2xlarge
 	  - r6a.4xlarge

--- a/templates/openedge-database.template.yaml
+++ b/templates/openedge-database.template.yaml
@@ -24,13 +24,129 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: t3a.medium
+    Default: t3.large
     AllowedValues:
-      - t3a.small
-      - t3a.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
+	  - m6i.xlarge
+	  - m6i.2xlarge
+	  - m6i.4xlarge
+	  - m6i.8xlarge
+	  - m6i.12xlarge
+	  - m6i.16xlarge
+	  - m6i.24xlarge
+	  - m6i.32xlarge
+	  - m6id.xlarge
+	  - m6id.2xlarge
+	  - m6id.4xlarge
+	  - m6id.8xlarge
+	  - m6id.12xlarge
+	  - m6id.16xlarge
+	  - m6id.24xlarge
+	  - m6id.32xlarge
+	  - m6in.xlarge
+	  - m6in.2xlarge
+	  - m6in.4xlarge
+	  - m6in.8xlarge
+	  - m6in.12xlarge
+	  - m6in.16xlarge
+	  - m6in.24xlarge
+	  - m6in.32xlarge
+	  - m6idn.xlarge
+	  - m6idn.2xlarge
+	  - m6idn.4xlarge
+	  - m6idn.8xlarge
+	  - m6idn.12xlarge
+	  - m6idn.16xlarge
+	  - m6idn.24xlarge
+	  - m6idn.32xlarge
+	  - m6a.xlarge
+	  - m6a.2xlarge
+	  - m6a.4xlarge
+	  - m6a.8xlarge
+	  - m6a.12xlarge
+	  - m6a.16xlarge
+	  - m6a.24xlarge
+	  - m6a.32xlarge
+	  - m6a.48xlarge
+	  - c6i.xlarge
+	  - c6i.2xlarge
+	  - c6i.4xlarge
+	  - c6i.8xlarge
+	  - c6i.12xlarge
+	  - c6i.16xlarge
+	  - c6i.24xlarge
+	  - c6i.32xlarge
+	  - c6id.xlarge
+	  - c6id.2xlarge
+	  - c6id.4xlarge
+	  - c6id.8xlarge
+	  - c6id.12xlarge
+	  - c6id.16xlarge
+	  - c6id.24xlarge
+	  - c6id.32xlarge
+	  - c6in.xlarge
+	  - c6in.2xlarge
+	  - c6in.4xlarge
+	  - c6in.8xlarge
+	  - c6in.12xlarge
+	  - c6in.16xlarge
+	  - c6in.24xlarge
+	  - c6in.32xlarge
+	  - c6a.xlarge
+	  - c6a.2xlarge
+	  - c6a.4xlarge
+	  - c6a.8xlarge
+	  - c6a.12xlarge
+	  - c6a.16xlarge
+	  - c6a.24xlarge
+	  - c6a.32xlarge
+	  - c6a.48xlarge
+	  - r6i.xlarge
+	  - r6i.2xlarge
+	  - r6i.4xlarge
+	  - r6i.8xlarge
+	  - r6i.12xlarge
+	  - r6i.16xlarge
+	  - r6i.24xlarge
+	  - r6i.32xlarge
+	  - r6id.xlarge
+	  - r6id.2xlarge
+	  - r6id.4xlarge
+	  - r6id.8xlarge
+	  - r6id.12xlarge
+	  - r6id.16xlarge
+	  - r6id.24xlarge
+	  - r6id.32xlarge
+	  - r6in.xlarge
+	  - r6in.2xlarge
+	  - r6in.4xlarge
+	  - r6in.8xlarge
+	  - r6in.12xlarge
+	  - r6in.16xlarge
+	  - r6in.24xlarge
+	  - r6in.32xlarge
+	  - r6idn.xlarge
+	  - r6idn.2xlarge
+	  - r6idn.4xlarge
+	  - r6idn.8xlarge
+	  - r6idn.12xlarge
+	  - r6idn.16xlarge
+	  - r6idn.24xlarge
+	  - r6idn.32xlarge
+	  - r6a.xlarge
+	  - r6a.2xlarge
+	  - r6a.4xlarge
+	  - r6a.8xlarge
+	  - r6a.12xlarge
+	  - r6a.16xlarge
+	  - r6a.24xlarge
+	  - r6a.32xlarge
+	  - r6a.48xlarge
     ConstraintDescription: must be a valid EC2 instance type.
   EmailAddress:
     Description: Email Address for notification
@@ -66,43 +182,43 @@ Mappings:
     AMI:
       OEDBAMZNLINUX2: Amazon Linux 2 AMI with OpenEdge Database
     af-south-1:
-      PASOEAMZNLINUX2: ami-0483b4c1afb4eda46
+      OEDBAMZNLINUX2: ami-01c73636859549498
     ap-east-1:
-      PASOEAMZNLINUX2: ami-0f34f73c9c1c4c5a1
+      OEDBAMZNLINUX2: ami-0cdeb044c645691b4
     ap-northeast-1:
-      PASOEAMZNLINUX2: ami-029df9bb050ef8112
+      OEDBAMZNLINUX2: ami-05e8c709fe67beee8
     ap-northeast-2:
-      PASOEAMZNLINUX2: ami-0e229f9260ad0b013
+      OEDBAMZNLINUX2: ami-0d261084b83e2e196
     ap-south-1:
-      PASOEAMZNLINUX2: ami-02a0dbded0d8b8096
+      OEDBAMZNLINUX2: ami-0580bb8aa5138f189
     ap-southeast-1:
-      PASOEAMZNLINUX2: ami-0a0385bc25f45793e
+      OEDBAMZNLINUX2: ami-05edf8978e91a8bf0
     ap-southeast-2:
-      PASOEAMZNLINUX2: ami-0871f7e7f3afeedb3
+      OEDBAMZNLINUX2: ami-0f55f3a20ef29d9c5
     ca-central-1:
-      PASOEAMZNLINUX2: ami-0aeaeac94c2608b8f
+      OEDBAMZNLINUX2: ami-0554ab9aaa47d698d
     eu-central-1:
-      PASOEAMZNLINUX2: ami-0a2e6a23a0a4781b9
+      OEDBAMZNLINUX2: ami-002da9196db239cc7
     eu-north-1:
-      PASOEAMZNLINUX2: ami-05fbeddf4f4483977
+      OEDBAMZNLINUX2: ami-0d410adb3583ce292
     eu-south-1:
-      PASOEAMZNLINUX2: ami-0347b276719afd4e4
+      OEDBAMZNLINUX2: ami-096c1ef55c7fd8a06
     eu-west-1:
-      PASOEAMZNLINUX2: ami-0d11972d0008af076
+      OEDBAMZNLINUX2: ami-059729eb93ef6b666
     eu-west-2:
-      PASOEAMZNLINUX2: ami-0cb95ff0a8a76a9a8
+      OEDBAMZNLINUX2: ami-07e80e872a2484bce
     eu-west-3:
-      PASOEAMZNLINUX2: ami-00a3f3b6e1e30a117
+      OEDBAMZNLINUX2: ami-014ec01d563109e34
     sa-east-1:
-      PASOEAMZNLINUX2: ami-09a5810b9df3765b3
+      OEDBAMZNLINUX2: ami-0babff01c9aae4922
     us-east-1:
-      PASOEAMZNLINUX2: ami-0a0664d4ac87ed6b6
+      OEDBAMZNLINUX2: ami-0e12666de7d0176d6
     us-east-2:
-      PASOEAMZNLINUX2: ami-092fe5237e3926fde
+      OEDBAMZNLINUX2: ami-03d9dbf1db41f13bb
     us-west-1:
-      PASOEAMZNLINUX2: ami-04ddd8681266f6db9
+      OEDBAMZNLINUX2: ami-0b192a6ab2f6ea4d6
     us-west-2:
-      PASOEAMZNLINUX2: ami-08c078385c21f45ef
+      OEDBAMZNLINUX2: ami-0573c0826395ec74d
 Resources:
   NotificationTopic:
     Type: "AWS::SNS::Topic"
@@ -113,7 +229,7 @@ Resources:
   S3AccessRole:
     Type: "AWS::IAM::Role"
     Properties:
-      Path: "/"     
+      Path: "/"
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:
@@ -128,16 +244,16 @@ Resources:
       PolicyName: S3AccessRolePolicy
       PolicyDocument:
         Version: "2012-10-17"
-        Statement:       
+        Statement:
         - Effect: Allow
           Action:
           - s3:Get*
           - s3:List*
           - s3:AbortMultipartUpload
           Resource:
-            - !Sub 'arn:${AWS::Partition}:s3:::${DeployBucket}/${DBDeployPackage}*'
-            - !Sub 'arn:${AWS::Partition}:s3:::${DeployBucket}'
-            - !Sub 'arn:${AWS::Partition}:s3:::${DeployBucket}/*'
+            - !Sub "arn:${AWS::Partition}:s3:::${DeployBucket}/${DBDeployPackage}*"
+            - !Sub "arn:${AWS::Partition}:s3:::${DeployBucket}"
+            - !Sub "arn:${AWS::Partition}:s3:::${DeployBucket}/*"
       Roles:
         - Ref: S3AccessRole
   S3AccessProfile:
@@ -167,7 +283,7 @@ Resources:
         - Key: Name
           Value: db1
       KeyName: !Ref KeyPairName
-      UserData: !Base64 
+      UserData: !Base64
         'Fn::Sub':
           - >
             #!/bin/bash -x
@@ -193,7 +309,7 @@ Resources:
             /install/app/deploy.sh
 
           - DeployRegion: !Ref DeployBucketRegion
-            DeployPackage: !Sub 's3://${DeployBucket}/${DBDeployPackage}'   
+            DeployPackage: !Sub 's3://${DeployBucket}/${DBDeployPackage}'
   TargetReplicaTwo:
     Type: "AWS::EC2::Instance"
     Metadata:
@@ -215,7 +331,7 @@ Resources:
         - Key: Name
           Value: db2
       KeyName: !Ref KeyPairName
-      UserData: !Base64 
+      UserData: !Base64
         'Fn::Sub':
           - >
             #!/bin/bash -x
@@ -263,7 +379,7 @@ Resources:
         - Key: Name
           Value: db0
       KeyName: !Ref KeyPairName
-      UserData: !Base64 
+      UserData: !Base64
         'Fn::Sub':
           - >
             #!/bin/bash -x
@@ -279,12 +395,12 @@ Resources:
             aws s3 cp ${DeployPackage} /install/app.tar.gz
 
             export OE_ENV=db0
-            
+
             export DBHostName=`curl http://169.254.169.254/latest/meta-data/local-ipv4`
 
             export DBHostName1=${DBHostName1}
-            
-            export DBHostName2=${DBHostName2}            
+
+            export DBHostName2=${DBHostName2}
 
             /opt/aws/bin/cfn-init -v --stack ${AWS::StackName} --resource SourceReplica --region ${AWS::Region}
 
@@ -301,7 +417,7 @@ Resources:
             DBHostName2:
               Fn::GetAtt:
                 - TargetReplicaTwo
-                - PrivateIp            
+                - PrivateIp
   InstanceSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Metadata:

--- a/templates/openedge-pasoe.template.yaml
+++ b/templates/openedge-pasoe.template.yaml
@@ -111,6 +111,7 @@ Parameters:
 	  - c6a.24xlarge
 	  - c6a.32xlarge
 	  - c6a.48xlarge
+	  - r6i.large
 	  - r6i.xlarge
 	  - r6i.2xlarge
 	  - r6i.4xlarge

--- a/templates/openedge-pasoe.template.yaml
+++ b/templates/openedge-pasoe.template.yaml
@@ -24,13 +24,129 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: t3a.small
+    Default: t3.large
     AllowedValues:
-      - t3a.small
-      - t3a.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
+	  - m6i.xlarge
+	  - m6i.2xlarge
+	  - m6i.4xlarge
+	  - m6i.8xlarge
+	  - m6i.12xlarge
+	  - m6i.16xlarge
+	  - m6i.24xlarge
+	  - m6i.32xlarge
+	  - m6id.xlarge
+	  - m6id.2xlarge
+	  - m6id.4xlarge
+	  - m6id.8xlarge
+	  - m6id.12xlarge
+	  - m6id.16xlarge
+	  - m6id.24xlarge
+	  - m6id.32xlarge
+	  - m6in.xlarge
+	  - m6in.2xlarge
+	  - m6in.4xlarge
+	  - m6in.8xlarge
+	  - m6in.12xlarge
+	  - m6in.16xlarge
+	  - m6in.24xlarge
+	  - m6in.32xlarge
+	  - m6idn.xlarge
+	  - m6idn.2xlarge
+	  - m6idn.4xlarge
+	  - m6idn.8xlarge
+	  - m6idn.12xlarge
+	  - m6idn.16xlarge
+	  - m6idn.24xlarge
+	  - m6idn.32xlarge
+	  - m6a.xlarge
+	  - m6a.2xlarge
+	  - m6a.4xlarge
+	  - m6a.8xlarge
+	  - m6a.12xlarge
+	  - m6a.16xlarge
+	  - m6a.24xlarge
+	  - m6a.32xlarge
+	  - m6a.48xlarge
+	  - c6i.xlarge
+	  - c6i.2xlarge
+	  - c6i.4xlarge
+	  - c6i.8xlarge
+	  - c6i.12xlarge
+	  - c6i.16xlarge
+	  - c6i.24xlarge
+	  - c6i.32xlarge
+	  - c6id.xlarge
+	  - c6id.2xlarge
+	  - c6id.4xlarge
+	  - c6id.8xlarge
+	  - c6id.12xlarge
+	  - c6id.16xlarge
+	  - c6id.24xlarge
+	  - c6id.32xlarge
+	  - c6in.xlarge
+	  - c6in.2xlarge
+	  - c6in.4xlarge
+	  - c6in.8xlarge
+	  - c6in.12xlarge
+	  - c6in.16xlarge
+	  - c6in.24xlarge
+	  - c6in.32xlarge
+	  - c6a.xlarge
+	  - c6a.2xlarge
+	  - c6a.4xlarge
+	  - c6a.8xlarge
+	  - c6a.12xlarge
+	  - c6a.16xlarge
+	  - c6a.24xlarge
+	  - c6a.32xlarge
+	  - c6a.48xlarge
+	  - r6i.xlarge
+	  - r6i.2xlarge
+	  - r6i.4xlarge
+	  - r6i.8xlarge
+	  - r6i.12xlarge
+	  - r6i.16xlarge
+	  - r6i.24xlarge
+	  - r6i.32xlarge
+	  - r6id.xlarge
+	  - r6id.2xlarge
+	  - r6id.4xlarge
+	  - r6id.8xlarge
+	  - r6id.12xlarge
+	  - r6id.16xlarge
+	  - r6id.24xlarge
+	  - r6id.32xlarge
+	  - r6in.xlarge
+	  - r6in.2xlarge
+	  - r6in.4xlarge
+	  - r6in.8xlarge
+	  - r6in.12xlarge
+	  - r6in.16xlarge
+	  - r6in.24xlarge
+	  - r6in.32xlarge
+	  - r6idn.xlarge
+	  - r6idn.2xlarge
+	  - r6idn.4xlarge
+	  - r6idn.8xlarge
+	  - r6idn.12xlarge
+	  - r6idn.16xlarge
+	  - r6idn.24xlarge
+	  - r6idn.32xlarge
+	  - r6a.xlarge
+	  - r6a.2xlarge
+	  - r6a.4xlarge
+	  - r6a.8xlarge
+	  - r6a.12xlarge
+	  - r6a.16xlarge
+	  - r6a.24xlarge
+	  - r6a.32xlarge
+	  - r6a.48xlarge
     ConstraintDescription: must be a valid EC2 instance type.
   EmailAddress:
     Description: Email Address for notification
@@ -39,7 +155,7 @@ Parameters:
       ([a-zA-Z0-9_\-\.]+)@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([a-zA-Z0-9\-]+\.)+))([a-zA-Z]{2,4}|[0-9]{1,3})(\]?)
     ConstraintDescription: Must be a valid email id.
   KeyPairName:
-    Type: 'AWS::EC2::KeyPair::KeyName'
+    Type: "AWS::EC2::KeyPair::KeyName"
     Description: Name of an existing EC2 KeyPair.
   WebAccessCIDR:
     AllowedPattern: >-
@@ -49,19 +165,19 @@ Parameters:
     Type: String
   PrivateSubnet1ID:
     Description: Private Subnet Id 1
-    Type: 'AWS::EC2::Subnet::Id'
+    Type: "AWS::EC2::Subnet::Id"
   PrivateSubnet2ID:
     Description: Private Subnet Id 2
-    Type: 'AWS::EC2::Subnet::Id'
+    Type: "AWS::EC2::Subnet::Id"
   PublicSubnet1ID:
     Description: Public Subnet Id 1
-    Type: 'AWS::EC2::Subnet::Id'
+    Type: "AWS::EC2::Subnet::Id"
   PublicSubnet2ID:
     Description: Public Subnet Id 2
-    Type: 'AWS::EC2::Subnet::Id'
+    Type: "AWS::EC2::Subnet::Id"
   VPCID:
-    Description: 'ID of the VPC (e.g., vpc-0343606e)'
-    Type: 'AWS::EC2::VPC::Id'
+    Description: "ID of the VPC (e.g., vpc-0343606e)"
+    Type: "AWS::EC2::VPC::Id"
   DBHostName:
     Description: IP Address of SourceReplica Instance
     Type: String
@@ -121,7 +237,7 @@ Mappings:
       PASOEAMZNLINUX2: ami-0a576313b11606919
 Resources:
   NotificationTopic:
-    Type: 'AWS::SNS::Topic'
+    Type: "AWS::SNS::Topic"
     Properties:
       Subscription:
         - Endpoint: !Ref EmailAddress
@@ -219,7 +335,7 @@ Resources:
     Properties:
       IamInstanceProfile: !Ref S3AccessProfile
       KeyName: !Ref KeyPairName
-      ImageId: !FindInMap 
+      ImageId: !FindInMap
         - AWSAMIRegionMap
         - !Ref 'AWS::Region'
         - PASOEAMZNLINUX2
@@ -378,9 +494,10 @@ Resources:
 Outputs:
   URL:
     Description: The URL of PASOE
-    Value: !Join 
+    Value: !Join
       - ''
       - - 'http://'
-        - !GetAtt 
+        - !GetAtt
           - ApplicationLoadBalancer
           - DNSName
+

--- a/templates/openedge-pasoe.template.yaml
+++ b/templates/openedge-pasoe.template.yaml
@@ -198,43 +198,43 @@ Mappings:
     AMI:
       PASOEAMZNLINUX2: Amazon Linux 2 AMI with PAS for OpenEdge
     af-south-1:
-      PASOEAMZNLINUX2: ami-040e27609bb7bf63c
+      PASOEAMZNLINUX2: ami-0c281b154dd811948
     ap-east-1:
-      PASOEAMZNLINUX2: ami-0ed126a2cb535416b
+      PASOEAMZNLINUX2: ami-0b61a0507f9c4b3dc
     ap-northeast-1:
-      PASOEAMZNLINUX2: ami-0b0a1707f6ed180d9
+      PASOEAMZNLINUX2: ami-09532d784a4b748f6
     ap-northeast-2:
-      PASOEAMZNLINUX2: ami-004b652dd831ab468
+      PASOEAMZNLINUX2: ami-04f9062f218e2e470
     ap-south-1:
-      PASOEAMZNLINUX2: ami-063596b1500b76519
+      PASOEAMZNLINUX2: ami-07955cfec4b6e87ad
     ap-southeast-1:
-      PASOEAMZNLINUX2: ami-0a4e99879372d6066
+      PASOEAMZNLINUX2: ami-0cd5f8a8496a1901c
     ap-southeast-2:
-      PASOEAMZNLINUX2: ami-0e2213fe83891355b
+      PASOEAMZNLINUX2: ami-0f226445cb78c05d8
     ca-central-1:
-      PASOEAMZNLINUX2: ami-0287de51dbea8991c
+      PASOEAMZNLINUX2: ami-0289a0b4ad342adc5
     eu-central-1:
-      PASOEAMZNLINUX2: ami-02421d3a9129b8ea4
+      PASOEAMZNLINUX2: ami-08e0f0207d1ab58b0
     eu-north-1:
-      PASOEAMZNLINUX2: ami-04caa36c22f41e4c3
+      PASOEAMZNLINUX2: ami-02c0d0e2eaf72abf4
     eu-south-1:
-      PASOEAMZNLINUX2: ami-0aaa1455fbcaf2d0d
+      PASOEAMZNLINUX2: ami-099fcf343ced32d87
     eu-west-1:
-      PASOEAMZNLINUX2: ami-0bcb9e5f58cf2cfc3
+      PASOEAMZNLINUX2: ami-0f40ef92d4e0987c6
     eu-west-2:
-      PASOEAMZNLINUX2: ami-0f865abc869dbc765
+      PASOEAMZNLINUX2: ami-0e079c6a6f04b774c
     eu-west-3:
-      PASOEAMZNLINUX2: ami-081e3b578af96619e
+      PASOEAMZNLINUX2: ami-08f880de72910f409
     sa-east-1:
-      PASOEAMZNLINUX2: ami-05fe9a1870842ae63
+      PASOEAMZNLINUX2: ami-05a9dbddb4865f867
     us-east-1:
-      PASOEAMZNLINUX2: ami-0b9eb7bc90d3cd1bc
+      PASOEAMZNLINUX2: ami-01509876f9479d692
     us-east-2:
-      PASOEAMZNLINUX2: ami-06ba8adbf1d9d25eb
+      PASOEAMZNLINUX2: ami-0e64ee530d5e7296d
     us-west-1:
-      PASOEAMZNLINUX2: ami-0473e5272cfeb7032
+      PASOEAMZNLINUX2: ami-08511b1e7eff4797d
     us-west-2:
-      PASOEAMZNLINUX2: ami-0a576313b11606919
+      PASOEAMZNLINUX2: ami-0eb4dcdcc76f797f3
 Resources:
   NotificationTopic:
     Type: "AWS::SNS::Topic"

--- a/templates/openedge-pasoe.template.yaml
+++ b/templates/openedge-pasoe.template.yaml
@@ -82,43 +82,43 @@ Mappings:
     AMI:
       PASOEAMZNLINUX2: Amazon Linux 2 AMI with PAS for OpenEdge
     af-south-1:
-      PASOEAMZNLINUX2: ami-057a0295f14ae2dbe
+      PASOEAMZNLINUX2: ami-040e27609bb7bf63c
     ap-east-1:
-      PASOEAMZNLINUX2: ami-0146ee721dff8d23c
+      PASOEAMZNLINUX2: ami-0ed126a2cb535416b
     ap-northeast-1:
-      PASOEAMZNLINUX2: ami-05016bf13ee342bb7
+      PASOEAMZNLINUX2: ami-0b0a1707f6ed180d9
     ap-northeast-2:
-      PASOEAMZNLINUX2: ami-0f28fbd1a32d3b7a5
+      PASOEAMZNLINUX2: ami-004b652dd831ab468
     ap-south-1:
-      PASOEAMZNLINUX2: ami-01949f4c78b61eaec
+      PASOEAMZNLINUX2: ami-063596b1500b76519
     ap-southeast-1:
-      PASOEAMZNLINUX2: ami-031115eff062dd3e6
+      PASOEAMZNLINUX2: ami-0a4e99879372d6066
     ap-southeast-2:
-      PASOEAMZNLINUX2: ami-0666cbd8ca3a73698
+      PASOEAMZNLINUX2: ami-0e2213fe83891355b
     ca-central-1:
-      PASOEAMZNLINUX2: ami-0a06948cfe9d941e7
+      PASOEAMZNLINUX2: ami-0287de51dbea8991c
     eu-central-1:
-      PASOEAMZNLINUX2: ami-0e14b0c5e1ab43f47
+      PASOEAMZNLINUX2: ami-02421d3a9129b8ea4
     eu-north-1:
-      PASOEAMZNLINUX2: ami-06fc7f880b4469c16
+      PASOEAMZNLINUX2: ami-04caa36c22f41e4c3
     eu-south-1:
-      PASOEAMZNLINUX2: ami-0bc2dd222eaddde21
+      PASOEAMZNLINUX2: ami-0aaa1455fbcaf2d0d
     eu-west-1:
-      PASOEAMZNLINUX2: ami-09bf9c3b0493c9569
+      PASOEAMZNLINUX2: ami-0bcb9e5f58cf2cfc3
     eu-west-2:
-      PASOEAMZNLINUX2: ami-04516eaa57902b285
+      PASOEAMZNLINUX2: ami-0f865abc869dbc765
     eu-west-3:
-      PASOEAMZNLINUX2: ami-008002eb0bb0f59a2
+      PASOEAMZNLINUX2: ami-081e3b578af96619e
     sa-east-1:
-      PASOEAMZNLINUX2: ami-09155f7b1be32f264
+      PASOEAMZNLINUX2: ami-05fe9a1870842ae63
     us-east-1:
-      PASOEAMZNLINUX2: ami-0b3bc3a12445d4c00
+      PASOEAMZNLINUX2: ami-0b9eb7bc90d3cd1bc
     us-east-2:
-      PASOEAMZNLINUX2: ami-0723f033c5d7a9400
+      PASOEAMZNLINUX2: ami-06ba8adbf1d9d25eb
     us-west-1:
-      PASOEAMZNLINUX2: ami-0e1f3d4ed8ae048a4
+      PASOEAMZNLINUX2: ami-0473e5272cfeb7032
     us-west-2:
-      PASOEAMZNLINUX2: ami-08ca23fed18d013fa
+      PASOEAMZNLINUX2: ami-0a576313b11606919
 Resources:
   NotificationTopic:
     Type: 'AWS::SNS::Topic'
@@ -384,4 +384,3 @@ Outputs:
         - !GetAtt 
           - ApplicationLoadBalancer
           - DNSName
-

--- a/templates/openedge-pasoe.template.yaml
+++ b/templates/openedge-pasoe.template.yaml
@@ -32,6 +32,7 @@ Parameters:
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
+	  - m6i.large
 	  - m6i.xlarge
 	  - m6i.2xlarge
 	  - m6i.4xlarge
@@ -40,6 +41,7 @@ Parameters:
 	  - m6i.16xlarge
 	  - m6i.24xlarge
 	  - m6i.32xlarge
+	  - m6id.large
 	  - m6id.xlarge
 	  - m6id.2xlarge
 	  - m6id.4xlarge
@@ -48,6 +50,7 @@ Parameters:
 	  - m6id.16xlarge
 	  - m6id.24xlarge
 	  - m6id.32xlarge
+	  - m6in.large
 	  - m6in.xlarge
 	  - m6in.2xlarge
 	  - m6in.4xlarge
@@ -56,6 +59,7 @@ Parameters:
 	  - m6in.16xlarge
 	  - m6in.24xlarge
 	  - m6in.32xlarge
+	  - m6idn.large
 	  - m6idn.xlarge
 	  - m6idn.2xlarge
 	  - m6idn.4xlarge
@@ -64,6 +68,7 @@ Parameters:
 	  - m6idn.16xlarge
 	  - m6idn.24xlarge
 	  - m6idn.32xlarge
+	  - m6a.large
 	  - m6a.xlarge
 	  - m6a.2xlarge
 	  - m6a.4xlarge
@@ -114,6 +119,7 @@ Parameters:
 	  - r6i.16xlarge
 	  - r6i.24xlarge
 	  - r6i.32xlarge
+	  - r6id.large
 	  - r6id.xlarge
 	  - r6id.2xlarge
 	  - r6id.4xlarge
@@ -122,6 +128,7 @@ Parameters:
 	  - r6id.16xlarge
 	  - r6id.24xlarge
 	  - r6id.32xlarge
+	  - r6in.large
 	  - r6in.xlarge
 	  - r6in.2xlarge
 	  - r6in.4xlarge
@@ -130,6 +137,7 @@ Parameters:
 	  - r6in.16xlarge
 	  - r6in.24xlarge
 	  - r6in.32xlarge
+	  - r6idn.large
 	  - r6idn.xlarge
 	  - r6idn.2xlarge
 	  - r6idn.4xlarge
@@ -138,6 +146,7 @@ Parameters:
 	  - r6idn.16xlarge
 	  - r6idn.24xlarge
 	  - r6idn.32xlarge
+	  - r6a.large
 	  - r6a.xlarge
 	  - r6a.2xlarge
 	  - r6a.4xlarge

--- a/templates/webserver.template.yaml
+++ b/templates/webserver.template.yaml
@@ -24,13 +24,57 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: t3a.medium
+    Default: t3.medium
     AllowedValues:
-      - t3a.small
+      - t3.medium
+      - t3.large
+      - t3.xlarge
+      - t3.2xlarge
       - t3a.medium
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
+	  - m6i.xlarge
+	  - m6i.2xlarge
+	  - m6i.4xlarge
+	  - m6i.8xlarge
+	  - m6i.12xlarge
+	  - m6i.16xlarge
+	  - m6i.24xlarge
+	  - m6i.32xlarge
+	  - m6id.xlarge
+	  - m6id.2xlarge
+	  - m6id.4xlarge
+	  - m6id.8xlarge
+	  - m6id.12xlarge
+	  - m6id.16xlarge
+	  - m6id.24xlarge
+	  - m6id.32xlarge
+	  - m6in.xlarge
+	  - m6in.2xlarge
+	  - m6in.4xlarge
+	  - m6in.8xlarge
+	  - m6in.12xlarge
+	  - m6in.16xlarge
+	  - m6in.24xlarge
+	  - m6in.32xlarge
+	  - m6idn.xlarge
+	  - m6idn.2xlarge
+	  - m6idn.4xlarge
+	  - m6idn.8xlarge
+	  - m6idn.12xlarge
+	  - m6idn.16xlarge
+	  - m6idn.24xlarge
+	  - m6idn.32xlarge
+	  - m6a.xlarge
+	  - m6a.2xlarge
+	  - m6a.4xlarge
+	  - m6a.8xlarge
+	  - m6a.12xlarge
+	  - m6a.16xlarge
+	  - m6a.24xlarge
+	  - m6a.32xlarge
+	  - m6a.48xlarge
     ConstraintDescription: must be a valid EC2 instance type.
   EmailAddress:
     Description: Email Address for notification
@@ -64,7 +108,7 @@ Parameters:
     Type: 'AWS::EC2::VPC::Id'
   PASOEURL:
     Description: URL to ELB to access PASOE
-    Type: String    
+    Type: String
   MinScalingInstances:
     Description: Minimum number of EC2 instances in ASG
     Type: String
@@ -217,14 +261,14 @@ Resources:
     Properties:
       IamInstanceProfile: !Ref S3AccessProfile
       KeyName: !Ref KeyPairName
-      ImageId: !FindInMap 
+      ImageId: !FindInMap
         - AWSAMIRegionMap
         - !Ref 'AWS::Region'
         - AmazonLinux2AMI
       InstanceType: !Ref InstanceType
       SecurityGroups:
         - !Ref WebServerSecurityGroup
-      UserData: !Base64 
+      UserData: !Base64
         'Fn::Sub':
           - >
             #!/bin/bash -x
@@ -371,7 +415,7 @@ Resources:
           - id: F1000
             reason: "Standard Amazon practice"
     Properties:
-      GroupDescription: Enable HTTP to the load balancer 
+      GroupDescription: Enable HTTP to the load balancer
       SecurityGroupIngress:
         - IpProtocol: tcp
           FromPort: 80
@@ -381,10 +425,10 @@ Resources:
 Outputs:
   URL:
     Description: The URL of WebServer
-    Value: !Join 
+    Value: !Join
       - ''
       - - 'http://'
-        - !GetAtt 
+        - !GetAtt
           - ApplicationLoadBalancer
           - DNSName
 

--- a/templates/webserver.template.yaml
+++ b/templates/webserver.template.yaml
@@ -34,6 +34,7 @@ Parameters:
       - t3a.large
       - t3a.xlarge
       - t3a.2xlarge
+	  - m6i.large
 	  - m6i.xlarge
 	  - m6i.2xlarge
 	  - m6i.4xlarge
@@ -42,6 +43,7 @@ Parameters:
 	  - m6i.16xlarge
 	  - m6i.24xlarge
 	  - m6i.32xlarge
+	  - m6id.large
 	  - m6id.xlarge
 	  - m6id.2xlarge
 	  - m6id.4xlarge
@@ -50,6 +52,7 @@ Parameters:
 	  - m6id.16xlarge
 	  - m6id.24xlarge
 	  - m6id.32xlarge
+	  - m6in.large
 	  - m6in.xlarge
 	  - m6in.2xlarge
 	  - m6in.4xlarge
@@ -58,6 +61,7 @@ Parameters:
 	  - m6in.16xlarge
 	  - m6in.24xlarge
 	  - m6in.32xlarge
+	  - m6idn.large
 	  - m6idn.xlarge
 	  - m6idn.2xlarge
 	  - m6idn.4xlarge
@@ -66,6 +70,7 @@ Parameters:
 	  - m6idn.16xlarge
 	  - m6idn.24xlarge
 	  - m6idn.32xlarge
+	  - m6a.large
 	  - m6a.xlarge
 	  - m6a.2xlarge
 	  - m6a.4xlarge

--- a/templates/webserver.template.yaml
+++ b/templates/webserver.template.yaml
@@ -120,47 +120,43 @@ Mappings:
     AMI:
       AmazonLinux2AMI: Amazon Linux 2 AMI
     af-south-1:
-      AmazonLinux2AMI: ami-0ec47ddb564d75b64
+      AmazonLinux2AMI: ami-0c9919139cb112e21
     ap-east-1:
-      AmazonLinux2AMI: ami-49bbfa38
+      AmazonLinux2AMI: ami-0f80f09f43db27f08
     ap-northeast-1:
-      AmazonLinux2AMI: ami-0a1c2ec61571737db
+      AmazonLinux2AMI: ami-07c2a88388bb80eb0
     ap-northeast-2:
-      AmazonLinux2AMI: ami-01af223aa7f274198
-    ap-northeast-3:
-      AmazonLinux2AMI: ami-053e733f02a27d9fc
+      AmazonLinux2AMI: ami-073858dcf4e30e586
     ap-south-1:
-      AmazonLinux2AMI: ami-0447a12f28fddb066
+      AmazonLinux2AMI: ami-078efad6f7ec18b8a
     ap-southeast-1:
-      AmazonLinux2AMI: ami-0615132a0f36d24f4
+      AmazonLinux2AMI: ami-06ebb7936bfa62864
     ap-southeast-2:
-      AmazonLinux2AMI: ami-088ff0e3bde7b3fdf
+      AmazonLinux2AMI: ami-0da25504d467cb134
     ca-central-1:
-      AmazonLinux2AMI: ami-0f75c2980c6a5851d
+      AmazonLinux2AMI: ami-0cbfa6bba4589dcbb
     eu-central-1:
-      AmazonLinux2AMI: ami-0a02ee601d742e89f
+      AmazonLinux2AMI: ami-08e415170f52d1657
     eu-north-1:
-      AmazonLinux2AMI: ami-04697c9bb5d6135a2
+      AmazonLinux2AMI: ami-042bae94a952c9eba
     eu-south-1:
-      AmazonLinux2AMI: ami-0f9b9a8cf93d838d0
+      AmazonLinux2AMI: ami-08226db9ffa402896
     eu-west-1:
-      AmazonLinux2AMI: ami-0ea3405d2d2522162
+      AmazonLinux2AMI: ami-0e23c576dacf2e3df
     eu-west-2:
-      AmazonLinux2AMI: ami-032598fcc7e9d1c7a
+      AmazonLinux2AMI: ami-0a6006bac3b9bb8d3
     eu-west-3:
-      AmazonLinux2AMI: ami-01c72e187b357583b
-    me-south-1:
-      AmazonLinux2AMI: ami-01b31491b74045c0c
+      AmazonLinux2AMI: ami-0c39e8f767a5e89c8
     sa-east-1:
-      AmazonLinux2AMI: ami-0477a95397a9154b3
+      AmazonLinux2AMI: ami-0c4bcf0e0554b7eb9
     us-east-1:
-      AmazonLinux2AMI: ami-09d95fab7fff3776c
+      AmazonLinux2AMI: ami-0bef6cc322bfff646
     us-east-2:
-      AmazonLinux2AMI: ami-026dea5602e368e96
+      AmazonLinux2AMI: ami-05842f1afbf311a43
     us-west-1:
-      AmazonLinux2AMI: ami-04e59c05167ea7bd5
+      AmazonLinux2AMI: ami-04669a22aad391419
     us-west-2:
-      AmazonLinux2AMI: ami-0e34e7b9ca0ace12d
+      AmazonLinux2AMI: ami-03c7c1f17ee073747
 Resources:
   NotificationTopic:
     Type: 'AWS::SNS::Topic'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Updated AMI IDs with OpenEdge 12.2.12 IDs for both Database and PASOE
- Added supported for multiple new instance types and removed support for few types
- Changed default instance type from t3.medium to t3.large

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
